### PR TITLE
Support Laravel 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ language: php
 
 matrix:
   include:
-    - php: 7.2
+    - php: 7.3
       env: LARAVEL='5.8.*'
-    - php: 7.2
-      env: LARAVEL='6.*'
     - php: 7.3
       env: LARAVEL='6.*'
     - php: 7.4
       env: LARAVEL='7.*'
+    - php: 7.4
+      env: LARAVEL='8.*'
   fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,16 @@
   ],
   "require": {
     "fewagency/carbonator": "^1.1",
-    "kontenta/kontour": "^1.0",
+    "kontenta/kontour": "^2.0",
     "bjuppa/laravel-blog": "^1.3"
   },
   "require-dev": {
-    "orchestra/testbench": "~3.8 || ^4.0 || ^5.0",
+    "orchestra/testbench": "~3.8 || ^4.0 || ^5.0 || ^6.0",
     "phpunit/phpunit": ">6.5",
     "mockery/mockery": "^1.0",
     "andrefigueira/blog-article-faker": "^1.0",
-    "squizlabs/php_codesniffer": "^3.4"
+    "squizlabs/php_codesniffer": "^3.4",
+    "laravel/legacy-factories": "^1.0.4"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Update dependencies & testing for Laravel 8.

- Bump kontenta/kontour requirement to `^2.0`
- Drop testing on PHP 7.2 because of `laravel/legacy-factories`